### PR TITLE
Don't apply styles until import is finished

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -20,7 +20,6 @@ globals:
   prefs: false
   reportError: true
   getActiveTab: true
-  shallowMerge: true
   t: true
   getCodeMirrorThemes: true
   setupLivePrefs: true

--- a/apply.js
+++ b/apply.js
@@ -52,6 +52,9 @@ function applyOnMessage(request, sender, sendResponse) {
 		case "styleDisableAll":
 			disableAll(request.disableAll);
 			break;
+		case "ping":
+			sendResponse(true);
+			break;
 	}
 }
 

--- a/background.js
+++ b/background.js
@@ -206,11 +206,13 @@ chrome.storage.local.get('version', prefs => {
 });
 
 // after the extension was enabled or just installed
+// reason = 'update' is needed becase our listener processes only 'update' events
 injectContentScripts({reason: 'update'});
+
 // after an actual update
 chrome.runtime.onInstalled.addListener(injectContentScripts);
 
-function injectContentScripts({reason, previousVersion, id, checkFirst} = {}) {
+function injectContentScripts({reason, previousVersion, id} = {}) {
 	// reason: install, update, chrome_update, shared_module_update
 	// the "install" case is ignored because it was already handled by explicit invocation of this function
 	if (!/update/.test(reason)) {

--- a/background.js
+++ b/background.js
@@ -62,10 +62,10 @@ chrome.runtime.onMessage.addListener(function(request, sender, sendResponse) {
 			&& sender.tab.url == request.matchUrl) {
 				updateIcon(sender.tab, styles);
 			}
-			return true;
+			return KEEP_CHANNEL_OPEN;
 		case "saveStyle":
-			saveStyle(request, sendResponse);
-			return true;
+			saveStyle(request).then(sendResponse);
+			return KEEP_CHANNEL_OPEN;
 		case "invalidateCache":
 			if (typeof invalidateCache != "undefined") {
 				invalidateCache(false);
@@ -73,7 +73,7 @@ chrome.runtime.onMessage.addListener(function(request, sender, sendResponse) {
 			break;
 		case "healthCheck":
 			getDatabase(function() { sendResponse(true); }, function() { sendResponse(false); });
-			return true;
+			return KEEP_CHANNEL_OPEN;
 		case "openURL":
 			openURL(request);
 			break;
@@ -88,6 +88,9 @@ chrome.runtime.onMessage.addListener(function(request, sender, sendResponse) {
 				chrome.contextMenus.update("disableAll", {checked: request.value});
 			}
 			break;
+		case "refreshAllTabs":
+			refreshAllTabs().then(sendResponse);
+			return KEEP_CHANNEL_OPEN;
 	}
 });
 

--- a/background.js
+++ b/background.js
@@ -205,19 +205,9 @@ chrome.storage.local.get('version', prefs => {
 	}
 });
 
-// after the extension was enabled or just installed
-// reason = 'update' is needed becase our listener processes only 'update' events
-injectContentScripts({reason: 'update'});
+injectContentScripts();
 
-// after an actual update
-chrome.runtime.onInstalled.addListener(injectContentScripts);
-
-function injectContentScripts({reason, previousVersion, id} = {}) {
-	// reason: install, update, chrome_update, shared_module_update
-	// the "install" case is ignored because it was already handled by explicit invocation of this function
-	if (!/update/.test(reason)) {
-		return;
-  }
+function injectContentScripts() {
 	const contentScripts = chrome.app.getDetails().content_scripts;
 	for (let cs of contentScripts) {
 		cs.matches = cs.matches.map(m => m == '<all_urls>' ? m : wildcardAsRegExp(m));

--- a/backup/fileSaveLoad.js
+++ b/backup/fileSaveLoad.js
@@ -1,4 +1,4 @@
-/* globals getStyles, saveStyle */
+/* globals getStyles, saveStyle, invalidateCache, refreshAllTabs, handleUpdate */
 'use strict';
 
 var STYLISH_DUMP_FILE_EXT = '.txt';
@@ -71,27 +71,26 @@ document.getElementById('file-all-styles').addEventListener('click', function ()
   });
 });
 
-document.getElementById('unfile-all-styles').addEventListener('click', function () {
-  loadFromFile(STYLISH_DUMPFILE_EXTENSION).then(function (rawText) {
-    var json = JSON.parse(rawText);
-    var i = 0, nextStyle;
+document.getElementById('unfile-all-styles').addEventListener('click', () => {
+  loadFromFile(STYLISH_DUMPFILE_EXTENSION).then(rawText => {
+    const json = JSON.parse(rawText);
+    const numStyles = json.length;
 
-    function done() {
-      window.alert(i + ' styles installed/updated');
-      location.reload();
-    }
+    invalidateCache(true);
+    proceed();
 
     function proceed() {
-      nextStyle = json[i++];
+      const nextStyle = json.shift();
       if (nextStyle) {
-        saveStyle(nextStyle, proceed);
-      }
-      else {
-        i--;
-        done();
+        saveStyle(nextStyle, {notify: false}).then(style => {
+          handleUpdate(style);
+          setTimeout(proceed, 0);
+        });
+      } else {
+        refreshAllTabs().then(() => {
+          setTimeout(alert, 100, numStyles + ' styles installed/updated');
+        });
       }
     }
-
-    proceed();
   });
 });

--- a/backup/fileSaveLoad.js
+++ b/backup/fileSaveLoad.js
@@ -55,7 +55,7 @@ function generateFileName() {
 
 document.getElementById('file-all-styles').addEventListener('click', function () {
   getStyles({}, function (styles) {
-    let text = JSON.stringify(styles);
+    let text = JSON.stringify(styles, null, '\t');
     let fileName = generateFileName() || STYLISH_DEFAULT_SAVE_NAME;
 
     let url = 'data:text/plain;charset=utf-8,' + encodeURIComponent(text);

--- a/edit.js
+++ b/edit.js
@@ -130,7 +130,7 @@ function initCodeMirror() {
 	var isWindowsOS = navigator.appVersion.indexOf("Windows") > 0;
 
 	// default option values
-	shallowMerge(CM.defaults, {
+	Object.assign(CM.defaults, {
 		mode: 'css',
 		lineNumbers: true,
 		lineWrapping: true,
@@ -1591,7 +1591,7 @@ function showCodeMirrorPopup(title, html, options) {
 	var popup = showHelp(title, html);
 	popup.classList.add("big");
 
-	popup.codebox = CodeMirror(popup.querySelector(".contents"), shallowMerge({
+	popup.codebox = CodeMirror(popup.querySelector(".contents"), Object.assign({
 		mode: "css",
 		lineNumbers: true,
 		lineWrapping: true,

--- a/edit.js
+++ b/edit.js
@@ -1,3 +1,4 @@
+/* globals stringAsRegExp */
 "use strict";
 
 var styleId = null;
@@ -1642,10 +1643,6 @@ chrome.runtime.onMessage.addListener(function(request, sender, sendResponse) {
 			}
 	}
 });
-
-function stringAsRegExp(s, flags) {
-	return new RegExp(s.replace(/[{}()\[\]\/\\.+?^$:=*!|]/g, "\\$&"), flags);
-}
 
 function getComputedHeight(el) {
 	var compStyle = getComputedStyle(el);

--- a/manage.html
+++ b/manage.html
@@ -159,6 +159,36 @@
             overflow: auto;
             margin: 0 0 .5em 0;
         }
+        /* drag-n-drop on import button */
+        .dropzone:after {
+            background-color: rgba(0, 0, 0, 0.7);
+            color: white;
+            left: 0;
+            top: 0;
+            right: 0;
+            bottom: 0;
+            z-index: 1000;
+            position: fixed;
+            padding: calc(50vh - 3em) calc(50vw - 5em);
+            content: attr(dragndrop-hint);
+            text-shadow: 1px 1px 10px black;
+            font-size: xx-large;
+            text-align: center;
+            animation: fadein 1s cubic-bezier(.03,.67,.08,.94);
+            animation-fill-mode: both;
+        }
+        .fadeout.dropzone:after {
+            animation: fadeout .25s ease-in-out;
+            animation-fill-mode: both;
+        }
+        @keyframes fadein {
+            from { opacity: 0; }
+            to   { opacity: 1; }
+        }
+        @keyframes fadeout {
+            from { opacity: 1; }
+            to   { opacity: 0; }
+        }
     </style>
 
     <template data-id="style">
@@ -191,7 +221,7 @@
     <script src="manage.js"></script>
 </head>
 
-<body id="stylus-manage">
+<body id="stylus-manage" i18n-dragndrop-hint="backupMessage">
     <div id="header">
         <h1 id="manage-heading" i18n-text="manageHeading"></h1>
         <fieldset>
@@ -240,7 +270,7 @@
             </div>
         </div>
         <div id="backup">
-            <h2 id="backup" i18n-text="backupButtons"></h2>
+            <h2 id="backup-title" i18n-text="backupButtons"></h2>
             <span id="backup-message" i18n-text="backupMessage"></span>
             <p>
                 <button id="file-all-styles" i18n-text="bckpInstStyles"></button>

--- a/manage.js
+++ b/manage.js
@@ -1,3 +1,4 @@
+/* globals styleSectionsEqual */
 var lastUpdatedStyleId = null;
 var installed;
 
@@ -257,7 +258,7 @@ function checkUpdate(element, callback) {
 		chrome.runtime.sendMessage({method: "getStyles", id: id}, function(styles) {
 			var style = styles[0];
 			var needsUpdate = false;
-			if (!forceUpdate && codeIsEqual(style.sections, serverJson.sections)) {
+			if (!forceUpdate && styleSectionsEqual(style, serverJson)) {
 				handleNeedsUpdate("no", id, serverJson);
 			} else {
 				handleNeedsUpdate("yes", id, serverJson);
@@ -366,58 +367,6 @@ function doUpdate(event) {
 	// updating the UI will be handled by the general update listener
 	lastUpdatedStyleId = updatedCode.id;
 	chrome.runtime.sendMessage(updatedCode, function () {});
-}
-
-function codeIsEqual(a, b) {
-	if (a.length != b.length) {
-		return false;
-	}
-	var properties = ["code", "urlPrefixes", "urls", "domains", "regexps"];
-	for (var i = 0; i < a.length; i++) {
-		var found = false;
-		for (var j = 0; j < b.length; j++) {
-			var allEquals = properties.every(function(property) {
-				return jsonEquals(a[i], b[j], property);
-			});
-			if (allEquals) {
-				found = true;
-				break;
-			}
-		}
-		if (!found) {
-			return false;
-		}
-	}
-	return true;
-}
-
-function jsonEquals(a, b, property) {
-	var aProp = a[property], typeA = getType(aProp);
-	var bProp = b[property], typeB = getType(bProp);
-	if (typeA != typeB) {
-		// consider empty arrays equivalent to lack of property
-		if ((typeA == "undefined" || (typeA == "array" && aProp.length == 0)) && (typeB == "undefined" || (typeB == "array" && bProp.length == 0))) {
-			return true;
-		}
-		return false;
-	}
-	if (typeA == "undefined") {
-		return true;
-	}
-	if (typeA == "array") {
-		if (aProp.length != bProp.length) {
-			return false;
-		}
-		for (var i = 0; i < aProp.length; i++) {
-			if (bProp.indexOf(aProp[i]) == -1) {
-				return false;
-			}
-		}
-		return true;
-	}
-	if (typeA == "string") {
-		return aProp == bProp;
-	}
 }
 
 function searchStyles(immediately) {

--- a/messaging.js
+++ b/messaging.js
@@ -1,12 +1,15 @@
 // keep message channel open for sendResponse in chrome.runtime.onMessage listener
 const KEEP_CHANNEL_OPEN = true;
+const OWN_ORIGIN = chrome.runtime.getURL('');
 
 function notifyAllTabs(request) {
-	chrome.windows.getAll({populate: true}, function(windows) {
-		windows.forEach(function(win) {
-			win.tabs.forEach(function(tab) {
-				chrome.tabs.sendMessage(tab.id, request);
-				updateIcon(tab);
+	chrome.windows.getAll({populate: true}, windows => {
+		windows.forEach(win => {
+			win.tabs.forEach(tab => {
+				if (request.codeIsUpdated !== false || tab.url.startsWith(OWN_ORIGIN)) {
+					chrome.tabs.sendMessage(tab.id, request);
+					updateIcon(tab);
+				}
 			});
 		});
 	});

--- a/messaging.js
+++ b/messaging.js
@@ -14,7 +14,7 @@ function notifyAllTabs(request) {
 		});
 	});
 	// notify all open popups
-	var reqPopup = shallowMerge({}, request, {method: "updatePopup", reason: request.method});
+	const reqPopup = Object.assign({}, request, {method: 'updatePopup', reason: request.method});
 	chrome.runtime.sendMessage(reqPopup);
 	// notify self: the message no longer is sent to the origin in new Chrome
 	if (typeof applyOnMessage !== 'undefined') {

--- a/messaging.js
+++ b/messaging.js
@@ -123,3 +123,12 @@ function getTabRealURL(tab, callback) {
 		});
 	}
 }
+
+function stringAsRegExp(s, flags) {
+	return new RegExp(s.replace(/[{}()\[\]\/\\.+?^$:=*!|]/g, "\\$&"), flags);
+}
+
+// expands * as .*?
+function wildcardAsRegExp(s, flags) {
+	return new RegExp(s.replace(/[{}()\[\]\/\\.+?^$:=!|]/g, "\\$&").replace(/\*/g, '.*?'), flags);
+}

--- a/storage.js
+++ b/storage.js
@@ -521,17 +521,6 @@ function deepMerge(target, obj1 /* plus any number of object arguments */) {
 	return target;
 }
 
-function shallowMerge(target, obj1 /* plus any number of object arguments */) {
-	for (var i = 1; i < arguments.length; i++) {
-		var obj = arguments[i];
-		for (var k in obj) {
-			target[k] = obj[k];
-			// hasOwnProperty checking is not needed for our non-OOP stuff
-		}
-	}
-	return target;
-}
-
 function equal(a, b) {
 	if (!a || !b || typeof a != "object" || typeof b != "object") {
 		return a === b;

--- a/storage.js
+++ b/storage.js
@@ -574,3 +574,34 @@ function getSync() {
 		}
 	}
 }
+
+function styleSectionsEqual(styleA, styleB) {
+	if (styleA.sections.length != styleB.sections.length) {
+		return false;
+	}
+	const properties = ['code', 'urlPrefixes', 'urls', 'domains', 'regexps'];
+	return styleA.sections.every(sectionA =>
+		styleB.sections.some(sectionB =>
+			properties.every(property => sectionEquals(sectionA, sectionB, property))
+		)
+	);
+
+	function sectionEquals(a, b, property) {
+		const aProp = a[property], typeA = getType(aProp);
+		const bProp = b[property], typeB = getType(bProp);
+		if (typeA != typeB) {
+			// consider empty arrays equivalent to lack of property
+			return ((typeA == 'undefined' || (typeA == 'array' && aProp.length == 0)) &&
+				(typeB == 'undefined' || (typeB == 'array' && bProp.length == 0)));
+		}
+		if (typeA == 'undefined') {
+			return true;
+		}
+		if (typeA == 'array') {
+			return aProp.length == bProp.length && aProp.every(item => bProp.includes(item));
+		}
+		if (typeA == 'string') {
+			return aProp == bProp;
+		}
+	}
+}

--- a/storage.js
+++ b/storage.js
@@ -105,11 +105,13 @@ function saveStyle(style, {notify = true} = {}) {
 			if (style.id) {
 				style.id = Number(style.id);
 				os.get(style.id).onsuccess = eventGet => {
-					style = Object.assign({}, eventGet.target.result, style);
+					const oldStyle = Object.assign({}, eventGet.target.result);
+					const codeIsUpdated = !styleSectionsEqual(style, oldStyle);
+					style = Object.assign(oldStyle, style);
 					os.put(style).onsuccess = eventPut => {
 						style.id = style.id || eventPut.target.result;
 						if (notify) {
-							notifyAllTabs({method: 'styleUpdated', style});
+							notifyAllTabs({method: 'styleUpdated', style, codeIsUpdated});
 						}
 						invalidateCache(notify);
 						resolve(style);
@@ -576,6 +578,9 @@ function getSync() {
 }
 
 function styleSectionsEqual(styleA, styleB) {
+	if (!styleA.sections || !styleB.sections) {
+		return undefined;
+	}
 	if (styleA.sections.length != styleB.sections.length) {
 		return false;
 	}

--- a/update.js
+++ b/update.js
@@ -71,7 +71,7 @@ var update = {
             json.method = 'saveStyle';
             json.id = style.id;
 
-            saveStyle(json, function () {
+            saveStyle(json).then(style => {
               observe('single-updated', style.name);
             });
           }


### PR DESCRIPTION
**Please test.**
For those who don't have git: [Zip](https://github.com/schomery/stylish-chrome/archive/fast-import.zip).

The old code have been rebuilding the style cache from IndexedDB and re-applying the styles to all opened tabs after each style was imported and saved. So in case you had 100 tabs open and 100 styles were imported the code did 100 * 100 = 10,000 repetitions of complex actions.

Now all styles are imported first, then all tabs are updated.

P.S. We should do something with the legacy code mess indeed... it's terrible, now that I look at it after all those years lol. Promises, ES6 are supported since Chrome 45 so no need to look back. OTOH, maybe it's better to do it in small chunks related to the task at hand.