### PR TITLE
Fix: don't use null as id

### DIFF
--- a/manage/import-export.js
+++ b/manage/import-export.js
@@ -161,7 +161,7 @@ function importFromString(jsonString) {
       if (sameStyle(byId, item)) {
         oldStyle = byId;
       } else {
-        item.id = null;
+        delete item.id;
       }
     }
     if (!oldStyle && byName) {


### PR DESCRIPTION
Using `null` as the id will throw when inserting to indexedDB.